### PR TITLE
Add param to shift pose publication ts

### DIFF
--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -92,6 +92,10 @@ HectorMappingRos::HectorMappingRos()
   private_nh_.param("output_timing", p_timing_output_,false);
 
   private_nh_.param("map_pub_period", p_map_pub_period_, 2.0);
+  // Offset (ROS Duration) to add to pose data when publishing it. A
+  // positive value shifts the pose ts to the future and enables using
+  // move base to move around while mapping.
+  private_nh_.param("transform_tolerance", p_transform_tolerance_, 1.0);
 
   double tmp = 0.0;
   private_nh_.param("laser_min_dist", tmp, 0.4);
@@ -177,6 +181,7 @@ HectorMappingRos::HectorMappingRos()
   ROS_INFO("HectorSM p_map_update_angle_threshold_: %f", p_map_update_angle_threshold_);
   ROS_INFO("HectorSM p_laser_z_min_value_: %f", p_laser_z_min_value_);
   ROS_INFO("HectorSM p_laser_z_max_value_: %f", p_laser_z_max_value_);
+  ROS_INFO("HectorSM p_transform_tolerance_: %f", p_transform_tolerance_);
 
   scanSubscriber_ = node_.subscribe(p_scan_topic_, p_scan_subscriber_queue_size_, &HectorMappingRos::scanCallback, this);
   sysMsgSubscriber_ = node_.subscribe(p_sys_msg_topic_, 2, &HectorMappingRos::sysMsgCallback, this);
@@ -345,7 +350,7 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan)
       odom_to_base.setIdentity();
     }
     map_to_odom_ = tf::Transform(poseInfoContainer_.getTfTransform() * odom_to_base.inverse());
-    tfB_->sendTransform( tf::StampedTransform (map_to_odom_, scan.header.stamp, p_map_frame_, p_odom_frame_));
+    tfB_->sendTransform( tf::StampedTransform (map_to_odom_, scan.header.stamp + ros::Duration(p_transform_tolerance_), p_map_frame_, p_odom_frame_));
   }
 
   if (p_pub_map_scanmatch_transform_){

--- a/hector_mapping/src/HectorMappingRos.h
+++ b/hector_mapping/src/HectorMappingRos.h
@@ -177,6 +177,7 @@ protected:
   int p_map_multi_res_levels_;
 
   double p_map_pub_period_;
+  double p_transform_tolerance_;
 
   bool p_use_tf_scan_transformation_;
   bool p_use_tf_pose_start_estimate_;


### PR DESCRIPTION
# Description

Fixes issue when trying to move the robot around with move base while using Hector SLAM:

```
[ WARN] [1593032629.741645891, 20.897000000]: Could not transform the global plan to the frame of the controller
[ERROR] [1593032629.842370228, 20.997000000]: Extrapolation Error: Lookup would require extrapolation into the future.  Requested time 20.970000000 but the latest data is at time 20.963000000, when looking up transform from frame [create1_tf/odom] to frame [map]

[ERROR] [1593032629.842409082, 20.997000000]: Global Frame: create1_tf/odom Plan Frame size 156: map
```
This is caused by the localization updates provided by Hector Mapping node being too slow for the local planner to use.

The fix is a workaround that adds an offset to the localization data's timestamp, simulating it's recent enough for the controller to use it.

# How Has This Been Tested?
Mapping with Hector SLAM while moving around with move base (see [Add Hector SLAM #217](https://github.com/RoboticaUtnFrba/create_autonomy/pull/217))